### PR TITLE
Adds a stop button to cancel table building

### DIFF
--- a/new/css/browser.css
+++ b/new/css/browser.css
@@ -48,7 +48,7 @@ img{
     font-size: 18pt;
 }
 
-.refresh, .quickMatch, .howToServe, .closeButton, .browserSwitch {
+.refresh, .stop, .quickMatch, .howToServe, .closeButton, .browserSwitch {
     opacity: 0.8;
     position: absolute;
     top: -9px;
@@ -69,17 +69,21 @@ img{
     left: 200px;
 }
 
+.stop {
+    left: 320px;
+}
+
 .quickMatch {
-    left: 590px;
+    left: 700px; 
 }
 
 .howToServe{
-    left: 700px;
+    left: 830px;
 }
 
 .browserSwitch{
     width: 125px;
-    left: 830px;
+    left: 960px;
 }
 
 .closeButton {
@@ -88,7 +92,7 @@ img{
     height: 28px;
 }
 
-.refresh:hover, .quickMatch:hover, .howToServe:hover, .closeButton:hover, .browserSwitch:hover{
+.refresh:hover, .stop:hover, .quickMatch:hover, .howToServe:hover, .closeButton:hover, .browserSwitch:hover{
     background-color: #B1572A;
 }
 
@@ -97,7 +101,7 @@ img{
     opacity: 0.8;
     position: absolute;
     top: -30px;
-    left: 350px;
+    left: 460px;
     z-index: 2;
     font-size: 14pt;
 }

--- a/new/index.html
+++ b/new/index.html
@@ -44,6 +44,7 @@
         <h3 class="browserTitle">Server Browser</h3>
         <h4 class="serverStats"><span class="playerCount">00 players</span>  /  <span class="serverCount">00 servers</span></h4>
         <div class="refresh" onclick="refreshTable();">Refresh</div>
+        <div class="stop" onclick="stopTableBuild();">Stop</div>
         <div class="quickMatch" onclick="quickMatch();">Quick Match</div>
         <div class="howToServe" onclick="howToServe();">How To Host</div>
         <div class="browserSwitch" onclick="switchBrowser();">Switch Browser</div>

--- a/new/js/browser.js
+++ b/new/js/browser.js
@@ -25,6 +25,7 @@ var repGP;
 var lastHeldUpdated = 0;
 var VerifyIPRegex = /^(?:(?:2[0-4]\d|25[0-5]|1\d{2}|[1-9]?\d)\.){3}(?:2[0-4]\d|25[0-5]|1\d{2}|[1-9]?\d)(?:\:(?:\d|[1-9]\d{1,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5]))?$/;
 var pageVisible = false;
+var stopTableBuilding = false
 
 swal.setDefaults({
     customClass: "alertWindow",
@@ -619,13 +620,16 @@ function oldBuildTable(server_list){
                     }
                     serverInfo["serverId"] = i;
                     serverInfo["serverIP"] = serverIP;
-                    if (serverInfo.maxPlayers <= 16 ) {
+
+                    if (stopTableBuilding) return;
+                    
+                    if (serverInfo.maxPlayers <= 16) {
                         if(serverInfo.map.length > 0) { //blank map means glitched server entry
                             for (var j = 0; j < serverList.servers.length; j++) {
                                 if (serverList.servers[j]["i"] == i) {
                                     serverList.servers[j] = serverInfo;
                                     if(serverInfo.eldewritoVersion.contains(gameVersion) || gameVersion == 0){
-                                    	playerCount+=parseInt(serverInfo.numPlayers);
+                                        playerCount+=parseInt(serverInfo.numPlayers);
                                         var playerOut = playerCount + " players";
                                         var serverOut = serverCount + " servers";
                                         $('.playerCount').html(playerOut);
@@ -684,7 +688,7 @@ function oldBuildTable(server_list){
                                 serverInfo.sprintUnlimitedEnabled,
                                 serverInfo.assassinationEnabled
                             ]).draw();
-                             if(serverInfo.eldewritoVersion.contains(gameVersion) || gameVersion == 0){
+                                if(serverInfo.eldewritoVersion.contains(gameVersion) || gameVersion == 0){
                                 serverCount++;
                             }
                             //fillGameCard(serverInfo.serverId);
@@ -698,7 +702,7 @@ function oldBuildTable(server_list){
                             }
                             //checkOfficial(serverInfo.serverIP);
                             if(!locked){
-                                //getFlag(serverIP,$("#serverTable").DataTable().column(0).data().length-1);
+                                getFlag(serverIP,$("#serverTable").DataTable().column(0).data().length-1);
                             }
                         } else {
                             console.log(serverInfo.serverIP + " is glitched");
@@ -707,7 +711,7 @@ function oldBuildTable(server_list){
                         console.log(serverInfo.serverIP + " is hacked (maxPlayers over 16)");
                     }
                 });
-              }, (i * pingDelay));  
+                }, (i * pingDelay));  
             })(i, serverIP);
         } else {
             console.log(serverIP + " is invalid, skipping.");
@@ -874,8 +878,13 @@ function refreshTable() {
     $('.playerCount').html(playerCount + " players");
     $('#serverTable').DataTable().clear().draw();
     selectedID = 0;
+    stopTableBuilding = false;
     //initCachejson();
     initDewjson();
+}
+
+function stopTableBuild() {
+    stopTableBuilding = true;
 }
 
 function quickMatch() {


### PR DESCRIPTION
This adds stop functionality to server table building. In the current state, users have to wait for completed server and table population before trying to join a server to avoid any unwanted bugs and side effects.

While this is not a final solution, it is a band-aid and is a feature most server browsers have utilized in the past anyway.