### PR TITLE
Make the stop button stop querying servers too

### DIFF
--- a/new/js/browser.js
+++ b/new/js/browser.js
@@ -597,6 +597,7 @@ function oldBuildTable(server_list){
             serverList.servers.push({serverIP, i});
             (function(i, serverIP) {
                 setTimeout(function() {
+                if (stopTableBuilding) return;                    
                 var startTime = Date.now();
                 var endTime;
                 var ping = 0;


### PR DESCRIPTION
atm it's just stopping the UI from updating while queries are still being sent out in the background, this should fix that